### PR TITLE
feat: Add Apothecary Magic Slots compatibility (SCGD)

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -99,7 +99,8 @@
       "Cantrip": "Cantrip",
       "SpellLevel": "Spell Level",
       "SpellSlots": "Spell Slots",
-      "PactMagic": "Pact Magic"
+      "PactMagic": "Pact Magic",
+      "ApothecaryMagic": "Apothecary Magic"
     },
     "Info": {
       "Skills": "Skills",

--- a/scripts/compatibility/README.md
+++ b/scripts/compatibility/README.md
@@ -1,0 +1,62 @@
+# Third-Party Module Compatibility
+
+This directory contains compatibility modules for integrating third-party Foundry VTT modules with the BG3 HUD D&D 5e adapter.
+
+## Architecture
+
+Each compatibility module is self-contained and follows a consistent pattern:
+
+1. **Detection**: Check if the feature is present on an actor
+2. **Normalization**: Convert the data to the HUD's standard resource format
+3. **Matching**: Identify which spells/items use the resource
+
+## Available Modules
+
+### scgd-apothecary.js
+**Module**: Sebastian Crowe's Guide to Drakkenheim (SCGD)
+**Feature**: Apothecary Magic Slots
+
+Detects and displays apothecary spell slots, similar to pact magic. Apothecary spells are automatically included in auto-population and can be filtered in the action bar.
+
+**Detection**: `actor.system.spells.apothecary`
+**Preparation Mode**: `apothecary`
+**Color**: `#285348` (deep green)
+
+## Adding New Compatibility
+
+To add support for a new third-party module:
+
+1. Create a new file: `<module-name>.js`
+2. Export these functions:
+   - `detect<Feature>(actor)` - Returns data or null
+   - `normalize<Feature>(actor)` - Returns HUD resource format or null
+   - `is<Feature>Spell(spell)` - Returns boolean (if applicable)
+3. Register in `index.js`:
+   - Import the module
+   - Add to `getCompatibilitySpellSlots()` if it provides spell slots
+   - Add to `getCompatibilityResourceForSpell()` if it affects spells
+   - Add to `getAlwaysPreparedModes()` if spells are always prepared
+4. Add localization strings to `lang/en.json`
+5. Add CSS variable in core's `base.css` if custom color needed
+
+## Resource Format
+
+Compatibility modules should return normalized resources in this format:
+
+```javascript
+{
+    id: 'spell-<type>',           // Unique identifier
+    label: 'Localized Label',     // Display name
+    short: 'X',                   // Short label (1-2 chars)
+    classes: ['spell-level-button', 'spell-<type>-box'],
+    color: '#hexcolor',           // CSS color
+    data: {
+        is<Type>: true,           // Type flag for filtering
+        value: number,            // Current slots
+        max: number,              // Maximum slots
+        level: number             // Slot level (optional)
+    },
+    value: number,                // For slot display
+    max: number                   // For slot display
+}
+```

--- a/scripts/compatibility/index.js
+++ b/scripts/compatibility/index.js
@@ -1,0 +1,64 @@
+/**
+ * Third-Party Module Compatibility Registry
+ *
+ * Coordinates all 3rd-party compatibility integrations for bg3-hud-dnd5e.
+ * Each compatibility module is self-contained and gracefully handles
+ * the absence of its target module.
+ *
+ * @module compatibility
+ */
+
+import * as SCGDApothecary from './scgd-apothecary.js';
+
+/**
+ * All registered compatibility modules
+ */
+const COMPATIBILITY_MODULES = {
+    'scgd-apothecary': SCGDApothecary
+};
+
+/**
+ * Get additional spell slots from all active compatibility modules
+ * @param {Actor5e} actor - The D&D 5e actor
+ * @returns {Array<Object>} Additional normalized spell slot resources
+ */
+export function getCompatibilitySpellSlots(actor) {
+    const slots = [];
+
+    // SCGD Apothecary Magic
+    const apothecarySlot = SCGDApothecary.normalizeApothecarySlots(actor);
+    if (apothecarySlot) {
+        slots.push(apothecarySlot);
+    }
+
+    // Future: Add more compatibility modules here
+
+    return slots;
+}
+
+/**
+ * Check if spell uses any compatibility-provided resource
+ * @param {Item5e} spell - The spell item
+ * @returns {string|null} Resource ID (e.g., 'apothecary') or null
+ */
+export function getCompatibilityResourceForSpell(spell) {
+    // Check SCGD
+    if (SCGDApothecary.isApothecarySpell(spell)) {
+        return 'apothecary';
+    }
+
+    // Future: Check other modules
+
+    return null;
+}
+
+/**
+ * Get list of preparation modes that are always prepared (from compatibility modules)
+ * @returns {Array<string>} Array of preparation mode strings
+ */
+export function getAlwaysPreparedModes() {
+    return [
+        'apothecary' // SCGD apothecary spells are always available when you have slots
+        // Future: Add more from other modules
+    ];
+}

--- a/scripts/compatibility/scgd-apothecary.js
+++ b/scripts/compatibility/scgd-apothecary.js
@@ -1,0 +1,79 @@
+/**
+ * Sebastian Crowe's Guide to Drakkenheim - Apothecary Magic Compatibility
+ *
+ * Detects and normalizes apothecary spell slots from the SCGD module.
+ * Apothecary Magic is a special spell slot type similar to Pact Magic,
+ * used by the Apothecary class from SCGD.
+ *
+ * @module compatibility/scgd-apothecary
+ */
+
+const MODULE_ID = 'bg3-hud-dnd5e';
+
+/**
+ * Detect apothecary magic slots on an actor
+ * @param {Actor5e} actor - The D&D 5e actor
+ * @returns {Object|null} Apothecary magic data or null if not present
+ */
+export function detectApothecaryMagic(actor) {
+    const apothecary = actor?.system?.spells?.apothecary;
+
+    if (!apothecary || apothecary.max <= 0) {
+        return null;
+    }
+
+    return {
+        value: apothecary.value ?? 0,
+        max: apothecary.max,
+        level: apothecary.level ?? 1
+    };
+}
+
+/**
+ * Normalize apothecary magic to HUD resource format
+ * @param {Actor5e} actor - The D&D 5e actor
+ * @returns {Object|null} Normalized spell slot resource or null
+ */
+export function normalizeApothecarySlots(actor) {
+    const data = detectApothecaryMagic(actor);
+
+    if (!data) return null;
+
+    return {
+        id: 'spell-apothecary',
+        label: game.i18n.localize(`${MODULE_ID}.Filters.ApothecaryMagic`),
+        short: 'A',
+        classes: ['spell-level-button', 'spell-apothecary-box'],
+        color: getComputedStyle(document.documentElement)
+            .getPropertyValue('--dnd5e-filter-apothecary')?.trim() || '#285348',
+        data: {
+            isApothecary: true,
+            value: data.value,
+            max: data.max,
+            level: data.level
+        },
+        value: data.value,
+        max: data.max
+    };
+}
+
+/**
+ * Check if a spell uses apothecary slots
+ * @param {Item5e} spell - The D&D 5e spell item
+ * @returns {boolean} True if spell uses apothecary preparation mode
+ */
+export function isApothecarySpell(spell) {
+    if (spell?.type !== 'spell') return false;
+
+    const method = spell.system?.method ?? spell.system?.preparation?.mode;
+    return method === 'apothecary';
+}
+
+/**
+ * Check if actor has any apothecary magic
+ * @param {Actor5e} actor - The D&D 5e actor
+ * @returns {boolean} True if actor has apothecary spell slots
+ */
+export function hasApothecaryMagic(actor) {
+    return detectApothecaryMagic(actor) !== null;
+}

--- a/scripts/components/containers/DnD5eFilterContainer.js
+++ b/scripts/components/containers/DnD5eFilterContainer.js
@@ -1,4 +1,5 @@
 import { FilterContainer } from '/modules/bg3-hud-core/scripts/components/containers/FilterContainer.js';
+import { normalizeApothecarySlots } from '../../compatibility/scgd-apothecary.js';
 
 const MODULE_ID = 'bg3-hud-dnd5e';
 
@@ -168,6 +169,12 @@ export class DnD5eFilterContainer extends FilterContainer {
             });
         }
 
+        // Apothecary Magic (Sebastian Crowe's Guide to Drakkenheim compatibility)
+        const apothecarySlot = normalizeApothecarySlots(this.actor);
+        if (apothecarySlot) {
+            spellSlotChildren.push(apothecarySlot);
+        }
+
         // Add spell slots group if there are any spell slots
         if (spellSlotChildren.length > 0) {
             filters.push({
@@ -210,6 +217,13 @@ export class DnD5eFilterContainer extends FilterContainer {
             const itemType = cell.dataset.itemType;
             if (itemType !== 'spell') return false;
             return cell.dataset.preparationMode === 'pact';
+        }
+
+        // Apothecary magic filter (SCGD compatibility)
+        if (filterData.isApothecary) {
+            const itemType = cell.dataset.itemType;
+            if (itemType !== 'spell') return false;
+            return cell.dataset.preparationMode === 'apothecary';
         }
 
         // Handle spell level filtering

--- a/scripts/features/DnD5eAutoPopulate.js
+++ b/scripts/features/DnD5eAutoPopulate.js
@@ -321,7 +321,7 @@ export class DnD5eAutoPopulate extends AutoPopulateFramework {
      * Check if spell is usable (prepared, always prepared, etc.)
      * When filtering is enabled for the actor type, only includes:
      * - Prepared spells (system.prepared !== 0)
-     * - At-will, innate, pact magic spells (method !== "spell")
+     * - At-will, innate, pact, apothecary magic spells (method !== "spell")
      * When disabled, includes all spells with a valid casting method.
      * @param {Actor} actor - The actor
      * @param {Item} item - The spell item

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -678,6 +678,11 @@ class DnD5eAdapter {
                             canCast = true;
                         }
 
+                        // Also check apothecary slots (SCGD compatibility)
+                        if (!canCast && spells.apothecary?.value > 0 && (spells.apothecary?.level ?? 1) >= level) {
+                            canCast = true;
+                        }
+
                         // Set depleted flag for GridCell to consume
                         cellData.depleted = !canCast;
                     }
@@ -822,6 +827,10 @@ class DnD5eAdapter {
                 }
                 // Also check pact slots
                 if (!canCast && spells.pact?.value > 0 && spells.pact?.level >= level) {
+                    canCast = true;
+                }
+                // Also check apothecary slots (SCGD compatibility)
+                if (!canCast && spells.apothecary?.value > 0 && (spells.apothecary?.level ?? 1) >= level) {
                     canCast = true;
                 }
 

--- a/styles/components/filters.css
+++ b/styles/components/filters.css
@@ -13,4 +13,5 @@
   --dnd5e-filter-spell: #3497d9;
   --dnd5e-filter-cantrip: #3497d9;
   --dnd5e-filter-pact: #7d3d97;
+  --dnd5e-filter-apothecary: #285348; /* SCGD Apothecary Magic - deep green */
 }


### PR DESCRIPTION
- Create compatibility module structure (scripts/compatibility/)
- Add scgd-apothecary.js for detecting and normalizing apothecary slots
- Update DnD5eFilterContainer to show apothcary magic in spell slots group
- Add filter matching logic for apothecary preparation mode
- Add CSS variable --dnd5e-filter-apothecary (#285348 deep green)
- Add localization string for Apothecary Magic filter
- Update spell depletion checks to consider apothecary slots
- Update auto-populate documentation to mention apothecary spells

Implements support for Sebastian Crowe's Guide to Drakkenheim module's apothecary spell slots, similar to pact magic.